### PR TITLE
Unit Tests for hub.go & channel.go

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestChannelSubscribe(t *testing.T) {
+	c := newChannel(newHub(), "/monkey")
+
+	// Assert no channels exist
+	if len(c.connections) != 0 {
+		t.Fatal("Error in test enviroment, Expectation: 0, Received:", len(c.connections))
+	}
+
+	c.subscribe(newTestConnection())
+	if len(c.connections) != 1 {
+		t.Fatal("Expectation: 1, Received:", len(c.connections))
+	}
+}
+
+func TestChannelPublish(t *testing.T) {
+	c := newChannel(newHub(), "/monkey")
+	conn := newTestConnection()
+
+	// Assert no channels exist
+	if len(c.connections) != 0 {
+		t.Fatal("Error in test enviroment, Expectation: 0, Received:", len(c.connections))
+	}
+
+	// Subscribe and Publish text to Channel
+	c.subscribe(conn)
+	c.publish([]byte("monkey"))
+	text := <-conn.send
+	if string(text) != "monkey" {
+		t.Fatal("Expectation: published text should be 'monkey', Received:", string(text))
+	}
+
+	// Publish should occur on all of the channel's connections
+	conn2 := newTestConnection()
+	c.subscribe(conn2)
+	c.publish([]byte("banana"))
+
+	text1, text2 := <-conn.send, <-conn2.send
+	if string(text1) != "banana" || string(text2) != "banana" {
+		t.Fatal("Expectation: published text for connections should be 'banana', Received:", string(text1), string(text1))
+	}
+
+	//Empty string should not publish
+	c.publish([]byte(""))
+	if len(conn.send) != 0 {
+		t.Fatal("Expectation: 0 - nil/empty string should not publish, Received:", len(conn.send))
+	}
+
+}
+
+func TestChannelUnsubscribe(t *testing.T) {
+	c := newChannel(newHub(), "/monkey")
+	conn := newTestConnection()
+	c.subscribe(conn)
+
+	c.unsubscribe(conn)
+	if len(c.connections) != 0 {
+		t.Fatal("Expectation: 0, Received:", len(c.connections))
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("ERR: channel conn.send not closed")
+		}
+	}()
+
+	conn.send <- []byte("")
+}
+
+func TestChannelStop(t *testing.T) {
+	c := newChannel(newHub(), "/monkey")
+	c.stop()
+	cmd := <-c.h.queue
+
+	if cmd.cmd != REMOVE {
+		t.Fatal("Expectation: cmd 4, Received:", cmd.cmd)
+	}
+}

--- a/channel_test.go
+++ b/channel_test.go
@@ -7,7 +7,7 @@ import (
 func TestChannelSubscribe(t *testing.T) {
 	c := newChannel(newHub(), "/monkey")
 
-	// Assert no channels exist
+	// Assert no connections exist
 	if len(c.connections) != 0 {
 		t.Fatal("Error in test enviroment, Expectation: 0, Received:", len(c.connections))
 	}
@@ -22,7 +22,7 @@ func TestChannelPublish(t *testing.T) {
 	c := newChannel(newHub(), "/monkey")
 	conn := newTestConnection()
 
-	// Assert no channels exist
+	// Assert no connections exist
 	if len(c.connections) != 0 {
 		t.Fatal("Error in test enviroment, Expectation: 0, Received:", len(c.connections))
 	}

--- a/hub.go
+++ b/hub.go
@@ -5,9 +5,8 @@ import (
 )
 
 type hub struct {
-	queue             queue
-	channels          channels
-	connectionManager connectionInterface
+	queue    queue
+	channels channels
 }
 
 type channels map[string]*channel
@@ -18,9 +17,8 @@ type connectionInterface interface {
 
 func newHub() *hub {
 	return &hub{
-		queue:             make(queue, 16),
-		channels:          make(channels),
-		connectionManager: connectionManager{},
+		queue:    make(queue, 16),
+		channels: make(channels),
 	}
 }
 
@@ -56,7 +54,7 @@ func (h *hub) subscribe(cmd command) {
 		go h.channels[cmd.path].run()
 	}
 	// Give the connection a reference to its own channel.
-	h.connectionManager.hubSubscribe(cmd, h)
+	cmd.conn.control <- h.channels[cmd.path]
 	h.channels[cmd.path].queue <- cmd
 }
 
@@ -77,10 +75,4 @@ func (h *hub) remove(cmd command) {
 	if _, ok := h.channels[cmd.path]; ok {
 		delete(h.channels, cmd.path)
 	}
-}
-
-type connectionManager struct{}
-
-func (cm connectionManager) hubSubscribe(cmd command, h *hub) {
-	cmd.conn.control <- h.channels[cmd.path]
 }

--- a/hub.go
+++ b/hub.go
@@ -11,10 +11,6 @@ type hub struct {
 
 type channels map[string]*channel
 
-type connectionInterface interface {
-	hubSubscribe(cmd command, h *hub)
-}
-
 func newHub() *hub {
 	return &hub{
 		queue:    make(queue, 16),

--- a/hub_test.go
+++ b/hub_test.go
@@ -75,7 +75,7 @@ func TestHubRun(t *testing.T) {
 
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("ERR: panic did not occur with invalid commnad")
+			t.Fatal("ERR: panic did not occur with invalid command")
 		}
 	}()
 

--- a/hub_test.go
+++ b/hub_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestSubscribe(t *testing.T) {
-	h := newTestHub()
+	h := newHub()
 
 	if len(h.channels) != 0 {
 		t.Fatal("Expectation: 0, Received:", len(h.channels))
@@ -13,40 +13,40 @@ func TestSubscribe(t *testing.T) {
 
 	// subscribing to a new path should
 	// add a (1) channel to the hub
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
 	if len(h.channels) != 1 {
 		t.Fatal("Expectation: 1, Received:", len(h.channels))
 	}
 
 	// subscribing to the same path multiple times
 	// should use same channel
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
 
 	if len(h.channels) != 1 {
 		t.Fatal("Expectation: 1, Received:", len(h.channels))
 	}
 
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana", conn: newTestConnection()})
 	if len(h.channels) != 2 {
 		t.Fatal("Expectation: 2, Received:", len(h.channels))
 	}
 }
 
 func TestPublish(t *testing.T) {
-	h := newTestHub()
+	h := newHub()
 	// Publishing to a non-existant channel
 	// should drop meessage
-	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 1")})
+	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 1"), conn: newTestConnection()})
 	if _, ok := h.channels["/monkey"]; ok {
 		t.Fatal("Expectation: Channel should not exist without a Subscriber")
 	}
 
 	// Publishing to a open channel
 	// Command should be pushed onto channel queue
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
-	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 2")})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
+	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 2"), conn: newTestConnection()})
 	_, cmd := <-h.channels["/monkey"].queue, <-h.channels["/monkey"].queue
 	if string(cmd.text) != "banana 2" {
 		t.Fatal("Expectation: banana 2, Received:", string(cmd.text))
@@ -54,10 +54,10 @@ func TestPublish(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	h := newTestHub()
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
-	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana"})
-	h.remove(command{cmd: REMOVE, path: "/monkey"})
+	h := newHub()
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana", conn: newTestConnection()})
+	h.remove(command{cmd: REMOVE, path: "/monkey", conn: newTestConnection()})
 
 	if _, ok := h.channels["/monkey"]; ok {
 		t.Fatal("ERR: Channel not removed")
@@ -68,14 +68,8 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-func newTestHub() *hub {
-	return &hub{
-		queue:             make(queue, 16),
-		channels:          make(channels),
-		connectionManager: stubConnectionManager{},
+func newTestConnection() *connection {
+	return &connection{
+		control: make(chan *channel, 1),
 	}
 }
-
-type stubConnectionManager struct{}
-
-func (scm stubConnectionManager) hubSubscribe(cmd command, h *hub) {}

--- a/hub_test.go
+++ b/hub_test.go
@@ -68,6 +68,20 @@ func TestHubRemove(t *testing.T) {
 	}
 }
 
+func TestHubRun(t *testing.T) {
+	h := newHub()
+	cmd := command{cmd: 99, path: "/monkey", conn: newTestConnection()}
+	h.queue <- cmd
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("ERR: panic did not occur with invalid commnad")
+		}
+	}()
+
+	h.run()
+}
+
 func newTestConnection() *connection {
 	return &connection{
 		control: make(chan *channel, 1),

--- a/hub_test.go
+++ b/hub_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSubscribe(t *testing.T) {
+	h := newTestHub()
+
+	if len(h.channels) != 0 {
+		t.Fatal("Expectation: 0, Received:", len(h.channels))
+	}
+
+	// subscribing to a new path should
+	// add a (1) channel to the hub
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	if len(h.channels) != 1 {
+		t.Fatal("Expectation: 1, Received:", len(h.channels))
+	}
+
+	// subscribing to the same path multiple times
+	// should use same channel
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+
+	if len(h.channels) != 1 {
+		t.Fatal("Expectation: 1, Received:", len(h.channels))
+	}
+
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana"})
+	if len(h.channels) != 2 {
+		t.Fatal("Expectation: 2, Received:", len(h.channels))
+	}
+}
+
+func TestPublish(t *testing.T) {
+	h := newTestHub()
+	// Publishing to a non-existant channel
+	// should drop meessage
+	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 1")})
+	if _, ok := h.channels["/monkey"]; ok {
+		t.Fatal("Expectation: Channel should not exist without a Subscriber")
+	}
+
+	// Publishing to a open channel
+	// Command should be pushed onto channel queue
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 2")})
+	_, cmd := <-h.channels["/monkey"].queue, <-h.channels["/monkey"].queue
+	if string(cmd.text) != "banana 2" {
+		t.Fatal("Expectation: banana 2, Received:", string(cmd.text))
+	}
+}
+
+func TestRemove(t *testing.T) {
+	h := newTestHub()
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey"})
+	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana"})
+	h.remove(command{cmd: REMOVE, path: "/monkey"})
+
+	if _, ok := h.channels["/monkey"]; ok {
+		t.Fatal("ERR: Channel not removed")
+	}
+
+	if _, ok := h.channels["/banana"]; !ok {
+		t.Fatal("ERR: Channel removed")
+	}
+}
+
+func newTestHub() *hub {
+	return &hub{
+		queue:             make(queue, 16),
+		channels:          make(channels),
+		connectionManager: stubConnectionManager{},
+	}
+}
+
+type stubConnectionManager struct{}
+
+func (scm stubConnectionManager) hubSubscribe(cmd command, h *hub) {}

--- a/hub_test.go
+++ b/hub_test.go
@@ -37,7 +37,7 @@ func TestSubscribe(t *testing.T) {
 func TestPublish(t *testing.T) {
 	h := newHub()
 	// Publishing to a non-existant channel
-	// should drop meessage
+	// should drop message
 	h.publish(command{cmd: PUBLISH, path: "/monkey", text: []byte("banana 1"), conn: newTestConnection()})
 	if _, ok := h.channels["/monkey"]; ok {
 		t.Fatal("Expectation: Channel should not exist without a Subscriber")

--- a/hub_test.go
+++ b/hub_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestSubscribe(t *testing.T) {
+func TestHubSubscribe(t *testing.T) {
 	h := newHub()
 
 	if len(h.channels) != 0 {
@@ -34,7 +34,7 @@ func TestSubscribe(t *testing.T) {
 	}
 }
 
-func TestPublish(t *testing.T) {
+func TestHubPublish(t *testing.T) {
 	h := newHub()
 	// Publishing to a non-existant channel
 	// should drop message
@@ -53,7 +53,7 @@ func TestPublish(t *testing.T) {
 	}
 }
 
-func TestRemove(t *testing.T) {
+func TestHubRemove(t *testing.T) {
 	h := newHub()
 	h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})
 	h.subscribe(command{cmd: SUBSCRIBE, path: "/banana", conn: newTestConnection()})

--- a/hub_test.go
+++ b/hub_test.go
@@ -85,5 +85,6 @@ func TestHubRun(t *testing.T) {
 func newTestConnection() *connection {
 	return &connection{
 		control: make(chan *channel, 1),
+		send:    make(chan []byte, 256),
 	}
 }


### PR DESCRIPTION
Basic unit testing for methods around hub and channel.

Please let me know if there is a standardized format for test failure messages, for the most part I just printed the expectation and output.  

I chose to be super explicit when setting up the cases ie: "h.subscribe(command{cmd: SUBSCRIBE, path: "/monkey", conn: newTestConnection()})" to make it clear which events are triggering each action, but maybe it's overkill...

Depending on how the other tests go, I may modify this implementation.  
