### PR TITLE
Unit Tests: conn_test.go

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -59,7 +59,7 @@ func (c *connection) reader() {
 	c.w.wsSetPongHandler()
 
 	for {
-		err := c.processReadMessage()
+		err := c.readMessage()
 		if err != nil {
 			break
 		}
@@ -67,7 +67,7 @@ func (c *connection) reader() {
 	c.w.wsClose()
 }
 
-func (c *connection) processReadMessage() (err error) {
+func (c *connection) readMessage() (err error) {
 	_, message, err := c.w.wsReadMessage()
 	if err != nil {
 		return err

--- a/conn.go
+++ b/conn.go
@@ -58,13 +58,16 @@ func (c *connection) reader() {
 	c.w.wsSetReadDeadline()
 	c.w.wsSetPongHandler()
 
+	defer func() {
+		c.ws.Close()
+	}()
+
 	for {
 		err := c.readMessage()
 		if err != nil {
 			break
 		}
 	}
-	c.w.wsClose()
 }
 
 func (c *connection) readMessage() (err error) {

--- a/conn.go
+++ b/conn.go
@@ -23,7 +23,6 @@ type connection struct {
 	control chan *channel
 	channel *channel
 	send    chan []byte
-	ws      *websocket.Conn
 	h       *hub
 	path    string
 	w       websocketManager
@@ -33,7 +32,6 @@ func newConnection(ws *websocket.Conn, h *hub, path string) *connection {
 	return &connection{
 		control: make(chan *channel, 1),
 		send:    make(chan []byte, 256),
-		ws:      ws,
 		h:       h,
 		path:    path,
 		w:       websocketInteractor{ws: ws},
@@ -59,7 +57,7 @@ func (c *connection) reader() {
 	c.w.wsSetPongHandler()
 
 	defer func() {
-		c.ws.Close()
+		c.w.wsClose()
 	}()
 
 	for {
@@ -89,7 +87,7 @@ func (c *connection) writer(pingPeriod time.Duration) {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		c.ws.Close()
+		c.w.wsClose()
 	}()
 	for {
 		select {

--- a/conn.go
+++ b/conn.go
@@ -5,20 +5,6 @@ import (
 	"time"
 )
 
-const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-
-	// Time allowed to read the next pong message from the peer.
-	pongWait = 30 * time.Second
-
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
-
-	// Maximum message size allowed from peer.
-	maxMessageSize = 512
-)
-
 type connection struct {
 	control chan *channel
 	channel *channel
@@ -112,46 +98,4 @@ func (c *connection) writer(pingPeriod time.Duration) {
 func (c *connection) write(mt int, payload []byte) error {
 	c.w.wsSetWriteDeadline()
 	return c.w.wsWriteMessage(mt, payload)
-}
-
-type websocketManager interface {
-	wsSetReadLimit()
-	wsSetReadDeadline()
-	wsSetPongHandler()
-	wsReadMessage() (int, []byte, error)
-	wsSetWriteDeadline()
-	wsWriteMessage(int, []byte) error
-	wsClose()
-}
-
-type websocketInteractor struct {
-	ws *websocket.Conn
-}
-
-func (w websocketInteractor) wsSetReadLimit() {
-	w.ws.SetReadLimit(maxMessageSize)
-}
-
-func (w websocketInteractor) wsSetReadDeadline() {
-	w.ws.SetReadDeadline(time.Now().Add(pongWait))
-}
-
-func (w websocketInteractor) wsSetPongHandler() {
-	w.ws.SetPongHandler(func(s string) error { w.wsSetReadDeadline(); return nil })
-}
-
-func (w websocketInteractor) wsClose() {
-	w.ws.Close()
-}
-
-func (w websocketInteractor) wsReadMessage() (messageType int, p []byte, err error) {
-	return w.ws.ReadMessage()
-}
-
-func (w websocketInteractor) wsSetWriteDeadline() {
-	w.ws.SetWriteDeadline(time.Now().Add(writeWait))
-}
-
-func (w websocketInteractor) wsWriteMessage(messageType int, payload []byte) error {
-	return w.ws.WriteMessage(messageType, payload)
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -43,8 +43,13 @@ func TestConnReadMessage(t *testing.T) {
 
 	// On receipt of nil message, nil message published to conn.send
 	conn.w = mockWsInteractor{msg: []byte("")}
-	err = conn.readMessage()
 
+	// Assert conn.send length = 0 before test begins
+	if len(conn.send) != 0 {
+		t.Fatal("Expectation: send channel length should be 0, Received:", len(conn.send))
+	}
+
+	err = conn.readMessage()
 	if len(conn.send) != 1 {
 		t.Fatal("Expectation: send channel length should be 1, Received:", len(conn.send))
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestConnWriterErr(t *testing.T) {
+func TestConnReaderErr(t *testing.T) {
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{err: errors.New("Message Read Error")}
 
@@ -21,7 +21,7 @@ func TestConnWriterErr(t *testing.T) {
 	}
 }
 
-func TestConnWriterMessage(t *testing.T) {
+func TestConnReaderMessage(t *testing.T) {
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{msg: []byte("banana")}
 
@@ -37,7 +37,7 @@ func TestConnWriterMessage(t *testing.T) {
 	panic("kill infinite loop")
 }
 
-func TestConnWriterNilMessage(t *testing.T) {
+func TestConnReaderNilMessage(t *testing.T) {
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{msg: []byte("")}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -57,12 +57,6 @@ func TestConnWriterNilMessage(t *testing.T) {
 	panic("kill infinite loop")
 }
 
-// func newTestConnectionWS() *connection {
-// 	conn := newTestConnection()
-// 	conn.channel = &channel{queue: make(queue, 16), path: "/monkey"}
-// 	return conn
-// }
-
 func newTestConnection() *connection {
 	return &connection{
 		control: make(chan *channel, 1),

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-func TestConnProcessReadMessage(t *testing.T) {
+func TestConnReadMessage(t *testing.T) {
 	conn := newTestConnection()
 
 	// Assert on error, do nothing
 	conn.w = mockWsInteractor{err: errors.New("Message Read Error")}
-	err := conn.processReadMessage()
+	err := conn.readMessage()
 
 	if err == nil {
 		t.Fatal("No Error Returned")
@@ -26,7 +26,7 @@ func TestConnProcessReadMessage(t *testing.T) {
 
 	// On receipt of non-nil message, message is posted to queue
 	conn.w = mockWsInteractor{msg: []byte("banana")}
-	err = conn.processReadMessage()
+	err = conn.readMessage()
 
 	cmd := <-conn.channel.queue
 	if string(cmd.text) != "banana" {
@@ -39,7 +39,7 @@ func TestConnProcessReadMessage(t *testing.T) {
 
 	// On receipt of nil message, nil message published to conn.send
 	conn.w = mockWsInteractor{msg: []byte("")}
-	err = conn.processReadMessage()
+	err = conn.readMessage()
 
 	if len(conn.send) != 1 {
 		t.Fatal("Expectation: send channel length should be 1, Received:", len(conn.send))

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,12 +6,9 @@ import (
 	"time"
 )
 
-var testConnectionMessage []byte
-var errReadMsg error
-
 func TestConnWriterErr(t *testing.T) {
 	conn := newTestConnectionWS()
-	errReadMsg = errors.New("Message Read Error")
+	conn.w = mockWsInteractor{err: errors.New("Message Read Error")}
 
 	conn.reader()
 
@@ -22,13 +19,11 @@ func TestConnWriterErr(t *testing.T) {
 	if len(conn.channel.queue) != 0 {
 		t.Fatal("Expectation: conn channel length should be > 0, Received:", len(conn.channel.queue))
 	}
-	// reset errReadMsg to nil
-	errReadMsg = nil
 }
 
 func TestConnWriterMessage(t *testing.T) {
 	conn := newTestConnectionWS()
-	testConnectionMessage = []byte("banana")
+	conn.w = mockWsInteractor{msg: []byte("banana")}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -44,7 +39,7 @@ func TestConnWriterMessage(t *testing.T) {
 
 func TestConnWriterNilMessage(t *testing.T) {
 	conn := newTestConnectionWS()
-	testConnectionMessage = []byte("")
+	conn.w = mockWsInteractor{msg: []byte("")}
 
 	if len(conn.send) != 0 {
 		t.Fatal("Expectation: 0, Received:", len(conn.send))
@@ -64,13 +59,15 @@ func TestConnWriterNilMessage(t *testing.T) {
 
 func newTestConnectionWS() *connection {
 	conn := newTestConnection()
-	conn.w = mockWsInteractor{}
 	conn.channel = &channel{queue: make(queue, 16), path: "/monkey"}
 	conn.send = make(chan []byte, 256)
 	return conn
 }
 
-type mockWsInteractor struct{}
+type mockWsInteractor struct {
+	msg []byte
+	err error
+}
 
 func (mq mockWsInteractor) wsSetReadLimit() {}
 
@@ -81,5 +78,5 @@ func (mq mockWsInteractor) wsSetPongHandler() {}
 func (mq mockWsInteractor) wsClose() {}
 
 func (mq mockWsInteractor) wsReadMessage() (messageType int, p []byte, err error) {
-	return messageType, testConnectionMessage, errReadMsg
+	return messageType, mq.msg, mq.err
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConnWriterErr(t *testing.T) {
-	conn := newTestConnectionWS()
+	conn := newTestConnection()
 	conn.w = mockWsInteractor{err: errors.New("Message Read Error")}
 
 	conn.reader()
@@ -22,7 +22,7 @@ func TestConnWriterErr(t *testing.T) {
 }
 
 func TestConnWriterMessage(t *testing.T) {
-	conn := newTestConnectionWS()
+	conn := newTestConnection()
 	conn.w = mockWsInteractor{msg: []byte("banana")}
 
 	defer func() {
@@ -38,7 +38,7 @@ func TestConnWriterMessage(t *testing.T) {
 }
 
 func TestConnWriterNilMessage(t *testing.T) {
-	conn := newTestConnectionWS()
+	conn := newTestConnection()
 	conn.w = mockWsInteractor{msg: []byte("")}
 
 	if len(conn.send) != 0 {
@@ -57,11 +57,18 @@ func TestConnWriterNilMessage(t *testing.T) {
 	panic("kill infinite loop")
 }
 
-func newTestConnectionWS() *connection {
-	conn := newTestConnection()
-	conn.channel = &channel{queue: make(queue, 16), path: "/monkey"}
-	conn.send = make(chan []byte, 256)
-	return conn
+// func newTestConnectionWS() *connection {
+// 	conn := newTestConnection()
+// 	conn.channel = &channel{queue: make(queue, 16), path: "/monkey"}
+// 	return conn
+// }
+
+func newTestConnection() *connection {
+	return &connection{
+		control: make(chan *channel, 1),
+		send:    make(chan []byte, 256),
+		channel: &channel{queue: make(queue, 16), path: "/monkey"},
+	}
 }
 
 type mockWsInteractor struct {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+var testConnectionMessage []byte
+var errReadMsg error
+
+func TestConnWriterErr(t *testing.T) {
+	conn := newTestConnectionWS()
+	errReadMsg = errors.New("Message Read Error")
+
+	conn.reader()
+
+	if len(conn.send) != 0 {
+		t.Fatal("Expectation: send channel length should be > 0, Received:", len(conn.send))
+	}
+
+	if len(conn.channel.queue) != 0 {
+		t.Fatal("Expectation: conn channel length should be > 0, Received:", len(conn.channel.queue))
+	}
+	// reset errReadMsg to nil
+	errReadMsg = nil
+}
+
+func TestConnWriterMessage(t *testing.T) {
+	conn := newTestConnectionWS()
+	testConnectionMessage = []byte("banana")
+
+	defer func() {
+		if r := recover(); r != nil {
+			cmd := <-conn.channel.queue
+			if string(cmd.text) != "banana" {
+				t.Fatal("Expectation: banana, Received:", string(cmd.text))
+			}
+		}
+	}()
+	go conn.reader()
+	panic("kill infinite loop")
+}
+
+func TestConnWriterNilMessage(t *testing.T) {
+	conn := newTestConnectionWS()
+	testConnectionMessage = []byte("")
+
+	if len(conn.send) != 0 {
+		t.Fatal("Expectation: 0, Received:", len(conn.send))
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			// wait to eliminate possibility of race condition
+			time.Sleep(time.Nanosecond * 50000000)
+			if len(conn.send) == 0 {
+				t.Fatal("Expectation: send channel length should be > 0, Received:", len(conn.send))
+			}
+		}
+	}()
+	go conn.reader()
+	panic("kill infinite loop")
+}
+
+func newTestConnectionWS() *connection {
+	conn := newTestConnection()
+	conn.w = mockWsInteractor{}
+	conn.channel = &channel{queue: make(queue, 16), path: "/monkey"}
+	conn.send = make(chan []byte, 256)
+	return conn
+}
+
+type mockWsInteractor struct{}
+
+func (mq mockWsInteractor) wsSetReadLimit() {}
+
+func (mq mockWsInteractor) wsSetReadDeadline() {}
+
+func (mq mockWsInteractor) wsSetPongHandler() {}
+
+func (mq mockWsInteractor) wsClose() {}
+
+func (mq mockWsInteractor) wsReadMessage() (messageType int, p []byte, err error) {
+	return messageType, testConnectionMessage, errReadMsg
+}

--- a/hub_test.go
+++ b/hub_test.go
@@ -97,10 +97,3 @@ func TestHubRun(t *testing.T) {
 
 	h.run()
 }
-
-func newTestConnection() *connection {
-	return &connection{
-		control: make(chan *channel, 1),
-		send:    make(chan []byte, 256),
-	}
-}

--- a/websocket.go
+++ b/websocket.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/gorilla/websocket"
+	"time"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 30 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 512
+)
+
+type websocketManager interface {
+	wsSetReadLimit()
+	wsSetReadDeadline()
+	wsSetPongHandler()
+	wsReadMessage() (int, []byte, error)
+	wsSetWriteDeadline()
+	wsWriteMessage(int, []byte) error
+	wsClose()
+}
+
+type websocketInteractor struct {
+	ws *websocket.Conn
+}
+
+func (w websocketInteractor) wsSetReadLimit() {
+	w.ws.SetReadLimit(maxMessageSize)
+}
+
+func (w websocketInteractor) wsSetReadDeadline() {
+	w.ws.SetReadDeadline(time.Now().Add(pongWait))
+}
+
+func (w websocketInteractor) wsSetPongHandler() {
+	w.ws.SetPongHandler(func(s string) error { w.wsSetReadDeadline(); return nil })
+}
+
+func (w websocketInteractor) wsClose() {
+	w.ws.Close()
+}
+
+func (w websocketInteractor) wsReadMessage() (messageType int, p []byte, err error) {
+	return w.ws.ReadMessage()
+}
+
+func (w websocketInteractor) wsSetWriteDeadline() {
+	w.ws.SetWriteDeadline(time.Now().Add(writeWait))
+}
+
+func (w websocketInteractor) wsWriteMessage(messageType int, payload []byte) error {
+	return w.ws.WriteMessage(messageType, payload)
+}


### PR DESCRIPTION
This PR covers unit tests for the conn.reader() and conn.writer.

Change summary:
1. To make the code more "testable" the websocket connection, and related methods have been moved to an interface.
2.  conn.writer() now accepts a param of type time.Duration to allow for arbitrary ping intervals
3. conn.reader() now calls conn.readMessage() to process incoming messages
