### PR TITLE
Single Ticker Per Hub

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -70,7 +70,15 @@ func (c *connection) readMessage() (err error) {
 }
 
 func (c *connection) writer(ticker <-chan time.Time) {
-	defer c.w.wsClose()
+
+	defer func() {
+		// restart writer if panic occurs
+		// due to blocked ticker chan
+		if r := recover(); r != nil {
+			c.writer(ticker)
+		}
+		c.w.wsClose()
+	}()
 
 	for {
 		select {

--- a/conn.go
+++ b/conn.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/gorilla/websocket"
-	"time"
 )
 
 type connection struct {
@@ -33,7 +32,7 @@ func (c *connection) run() {
 		decr("websockets", 1)
 		c.channel.queue <- command{cmd: UNSUBSCRIBE, conn: c, path: c.path}
 	}()
-	go c.writer(c.h.ticker.Subscribe())
+	go c.writer()
 	c.reader()
 }
 
@@ -69,7 +68,8 @@ func (c *connection) readMessage() (err error) {
 	return
 }
 
-func (c *connection) writer(ticker <-chan time.Time) {
+func (c *connection) writer() {
+	ticker := c.h.ticker.Subscribe()
 	defer c.w.wsClose()
 
 	for {

--- a/conn.go
+++ b/conn.go
@@ -70,15 +70,7 @@ func (c *connection) readMessage() (err error) {
 }
 
 func (c *connection) writer(ticker <-chan time.Time) {
-
-	defer func() {
-		// restart writer if panic occurs
-		// due to blocked ticker chan
-		if r := recover(); r != nil {
-			c.writer(ticker)
-		}
-		c.w.wsClose()
-	}()
+	defer c.w.wsClose()
 
 	for {
 		select {

--- a/conn_test.go
+++ b/conn_test.go
@@ -62,11 +62,14 @@ func TestConnReadMessage(t *testing.T) {
 }
 
 func TestConnWriter(t *testing.T) {
+	h := newHub()
+	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{}
-	ticker := multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+	conn.h = h
 
-	go conn.writer(ticker.Subscribe())
+	go conn.writer()
 	conn.send <- []byte("bananas")
 
 	// On receipt of valid message, message written
@@ -101,15 +104,17 @@ func TestSharedTicker(t *testing.T) {
 	for i := 0; i < 9; i++ {
 		conn := newTestConnection()
 		conn.path = "/monkey"
+		conn.h = h
 		conn.w = mockWsInteractor{}
-		go conn.writer(h.ticker.Subscribe())
+		go conn.writer()
 	}
 
 	// add connection on new path for control
 	conn2 := newTestConnection()
 	conn2.path = "/banana"
+	conn2.h = h
 	conn2.w = mockWsInteractor{}
-	go conn2.writer(h.ticker.Subscribe())
+	go conn2.writer()
 
 	time.Sleep(3 * time.Second)
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"github.com/VividCortex/multitick"
 	"testing"
 	"time"
 )
@@ -62,8 +63,9 @@ func TestConnReadMessage(t *testing.T) {
 func TestConnWriter(t *testing.T) {
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{}
+	ticker := multitick.NewTicker(2*time.Second, time.Millisecond*-1)
 
-	go conn.writer(2 * time.Second)
+	go conn.writer(ticker.Subscribe())
 	conn.send <- []byte("bananas")
 
 	// On receipt of valid message, message written

--- a/conn_test.go
+++ b/conn_test.go
@@ -97,21 +97,26 @@ func TestSharedTicker(t *testing.T) {
 	h := newHub()
 	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
 
-	for i := 0; i < 3; i++ {
+	// create multiple connections on the same path
+	for i := 0; i < 9; i++ {
 		conn := newTestConnection()
 		conn.path = "/monkey"
 		conn.w = mockWsInteractor{}
 		go conn.writer(h.ticker.Subscribe())
 	}
 
+	// add connection on new path for control
 	conn2 := newTestConnection()
 	conn2.path = "/banana"
 	conn2.w = mockWsInteractor{}
 	go conn2.writer(h.ticker.Subscribe())
 
 	time.Sleep(3 * time.Second)
-	if testTickerCount < 4 {
-		t.Fatal("Expected: Ticker Count >= 4, Received:", testTickerCount)
+
+	// Assert connections on the same path are not blocked
+	// by shared ticker
+	if testTickerCount < 10 {
+		t.Fatal("Expected: Ticker Count >= 10, Received:", testTickerCount)
 	}
 }
 

--- a/hub.go
+++ b/hub.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"fmt"
+	"github.com/VividCortex/multitick"
+	"time"
 )
 
 type hub struct {
 	queue    queue
 	channels channels
+	ticker   *multitick.Ticker
 }
 
 type channels map[string]*channel
@@ -15,6 +18,7 @@ func newHub() *hub {
 	return &hub{
 		queue:    make(queue, 16),
 		channels: make(channels),
+		ticker:   multitick.NewTicker(pingPeriod, time.Millisecond*-1),
 	}
 }
 
@@ -28,6 +32,8 @@ func newChannel(h *hub, path string) *channel {
 }
 
 func (h *hub) run() {
+	defer h.ticker.Stop()
+
 	for cmd := range h.queue {
 		// Forward cmds to their path's channel queues.
 		switch cmd.cmd {


### PR DESCRIPTION
Change Summary:
1. Remove Ticker form conn.write()
2. Add test to assert connections aren't blocked/locked by inability to access ticker chan.
3. Add package [multitick](https://godoc.org/github.com/VividCortex/multitick)
- multitick allows time chans to 'subscribe' to a ticker on an interval
- it could be something that we might want to self-implement (it's not too complicated) and we may not need the interval

Memory Savings: 
A local benchmark with 12 concurrent connections (9 unique paths–1 path had 3 connections) for 6 ping sessions.  Benchmark yielded the below results:

Multiple tickers (avg):
Alloc :  631704
Total Alloc :  631704
Sys :  3542140
Lookups :  24

Single ticker (avg):
Alloc :  629928
Total Alloc :  629928
Sys :  3542140
Lookups :  24

Next Steps:
This is a change I would merge w/ caution, I was only able to perform a simple benchmark locally but would recommend a more comprehensive load test done in a staging environment. It would be worthwhile to see what the memory savings actually is w/ more load.
