### PR TITLE
single ticker per hub

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -70,7 +70,15 @@ func (c *connection) readMessage() (err error) {
 }
 
 func (c *connection) writer(ticker <-chan time.Time) {
-	defer c.w.wsClose()
+
+	defer func() {
+		// restart writer if panic occurs
+		// due to blocked ticker chan
+		if r := recover(); r != nil {
+			c.writer(ticker)
+		}
+		c.w.wsClose()
+	}()
 
 	for {
 		select {

--- a/conn.go
+++ b/conn.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/gorilla/websocket"
-	"time"
 )
 
 type connection struct {
@@ -33,7 +32,7 @@ func (c *connection) run() {
 		decr("websockets", 1)
 		c.channel.queue <- command{cmd: UNSUBSCRIBE, conn: c, path: c.path}
 	}()
-	go c.writer(c.h.ticker.Subscribe())
+	go c.writer()
 	c.reader()
 }
 
@@ -69,7 +68,8 @@ func (c *connection) readMessage() (err error) {
 	return
 }
 
-func (c *connection) writer(ticker <-chan time.Time) {
+func (c *connection) writer() {
+	ticker := c.h.ticker.Subscribe()
 	defer c.w.wsClose()
 
 	for {

--- a/conn.go
+++ b/conn.go
@@ -70,15 +70,7 @@ func (c *connection) readMessage() (err error) {
 }
 
 func (c *connection) writer(ticker <-chan time.Time) {
-
-	defer func() {
-		// restart writer if panic occurs
-		// due to blocked ticker chan
-		if r := recover(); r != nil {
-			c.writer(ticker)
-		}
-		c.w.wsClose()
-	}()
+	defer c.w.wsClose()
 
 	for {
 		select {

--- a/conn_test.go
+++ b/conn_test.go
@@ -62,11 +62,14 @@ func TestConnReadMessage(t *testing.T) {
 }
 
 func TestConnWriter(t *testing.T) {
+	h := newHub()
+	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{}
-	ticker := multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+	conn.h = h
 
-	go conn.writer(ticker.Subscribe())
+	go conn.writer()
 	conn.send <- []byte("bananas")
 
 	// On receipt of valid message, message written
@@ -101,15 +104,17 @@ func TestSharedTicker(t *testing.T) {
 	for i := 0; i < 9; i++ {
 		conn := newTestConnection()
 		conn.path = "/monkey"
+		conn.h = h
 		conn.w = mockWsInteractor{}
-		go conn.writer(h.ticker.Subscribe())
+		go conn.writer()
 	}
 
 	// add connection on new path for control
 	conn2 := newTestConnection()
 	conn2.path = "/banana"
+	conn2.h = h
 	conn2.w = mockWsInteractor{}
-	go conn2.writer(h.ticker.Subscribe())
+	go conn2.writer()
 
 	time.Sleep(3 * time.Second)
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"github.com/VividCortex/multitick"
 	"testing"
 	"time"
 )
@@ -62,8 +63,9 @@ func TestConnReadMessage(t *testing.T) {
 func TestConnWriter(t *testing.T) {
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{}
+	ticker := multitick.NewTicker(2*time.Second, time.Millisecond*-1)
 
-	go conn.writer(2 * time.Second)
+	go conn.writer(ticker.Subscribe())
 	conn.send <- []byte("bananas")
 
 	// On receipt of valid message, message written

--- a/conn_test.go
+++ b/conn_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"github.com/VividCortex/multitick"
 	"testing"
 	"time"
 )
@@ -63,7 +62,7 @@ func TestConnReadMessage(t *testing.T) {
 
 func TestConnWriter(t *testing.T) {
 	h := newHub()
-	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+	h.ticker = newMTicker(2 * time.Second)
 
 	conn := newTestConnection()
 	conn.w = mockWsInteractor{}
@@ -98,7 +97,7 @@ func TestConnWriter(t *testing.T) {
 func TestSharedTicker(t *testing.T) {
 	testTickerCount = 0
 	h := newHub()
-	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
+	h.ticker = newMTicker(2 * time.Second)
 
 	// create multiple connections on the same path
 	for i := 0; i < 9; i++ {

--- a/conn_test.go
+++ b/conn_test.go
@@ -97,21 +97,26 @@ func TestSharedTicker(t *testing.T) {
 	h := newHub()
 	h.ticker = multitick.NewTicker(2*time.Second, time.Millisecond*-1)
 
-	for i := 0; i < 3; i++ {
+	// create multiple connections on the same path
+	for i := 0; i < 9; i++ {
 		conn := newTestConnection()
 		conn.path = "/monkey"
 		conn.w = mockWsInteractor{}
 		go conn.writer(h.ticker.Subscribe())
 	}
 
+	// add connection on new path for control
 	conn2 := newTestConnection()
 	conn2.path = "/banana"
 	conn2.w = mockWsInteractor{}
 	go conn2.writer(h.ticker.Subscribe())
 
 	time.Sleep(3 * time.Second)
-	if testTickerCount < 4 {
-		t.Fatal("Expected: Ticker Count >= 4, Received:", testTickerCount)
+
+	// Assert connections on the same path are not blocked
+	// by shared ticker
+	if testTickerCount < 10 {
+		t.Fatal("Expected: Ticker Count >= 10, Received:", testTickerCount)
 	}
 }
 

--- a/hub.go
+++ b/hub.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/VividCortex/multitick"
-	"time"
 )
 
 type hub struct {
 	queue    queue
 	channels channels
-	ticker   *multitick.Ticker
+	ticker   *mTicker
 }
 
 type channels map[string]*channel
@@ -18,7 +16,7 @@ func newHub() *hub {
 	return &hub{
 		queue:    make(queue, 16),
 		channels: make(channels),
-		ticker:   multitick.NewTicker(pingPeriod, time.Millisecond*-1),
+		ticker:   newMTicker(pingPeriod),
 	}
 }
 
@@ -32,7 +30,7 @@ func newChannel(h *hub, path string) *channel {
 }
 
 func (h *hub) run() {
-	defer h.ticker.Stop()
+	defer h.ticker.stop()
 
 	for cmd := range h.queue {
 		// Forward cmds to their path's channel queues.

--- a/hub.go
+++ b/hub.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"fmt"
+	"github.com/VividCortex/multitick"
+	"time"
 )
 
 type hub struct {
 	queue    queue
 	channels channels
+	ticker   *multitick.Ticker
 }
 
 type channels map[string]*channel
@@ -15,6 +18,7 @@ func newHub() *hub {
 	return &hub{
 		queue:    make(queue, 16),
 		channels: make(channels),
+		ticker:   multitick.NewTicker(pingPeriod, time.Millisecond*-1),
 	}
 }
 
@@ -28,6 +32,8 @@ func newChannel(h *hub, path string) *channel {
 }
 
 func (h *hub) run() {
+	defer h.ticker.Stop()
+
 	for cmd := range h.queue {
 		// Forward cmds to their path's channel queues.
 		switch cmd.cmd {

--- a/mticker.go
+++ b/mticker.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+type mTicker struct {
+	mux         sync.Mutex // Protects chans slice
+	subscribers subscribers
+
+	tickerMux sync.Mutex // Used to sync start/stop
+	ticker    *time.Ticker
+	stopCh    chan struct{}
+	stopped   bool
+	dropped   int
+}
+
+type subscribers map[*subscriber]interface {
+}
+
+type subscriber struct {
+	tick chan time.Time
+}
+
+// creates and starts a new ticker
+// that can have subscribed channels to receive
+// ticks
+func newMTicker(interval time.Duration) *mTicker {
+	t := &mTicker{
+		subscribers: make(subscribers),
+	}
+
+	go func() {
+		t.tickerMux.Lock()
+		stopped := t.stopped
+
+		if !stopped {
+			t.stopCh = make(chan struct{}, 1)
+			t.ticker = time.NewTicker(interval)
+		}
+		t.tickerMux.Unlock()
+
+		if !stopped {
+			t.tick()
+		}
+	}()
+	return t
+}
+
+func newSubscriber() *subscriber {
+	return &subscriber{
+		tick: make(chan time.Time, 1),
+	}
+}
+
+// Subscribe returns a channel to which ticks will be delivered. Ticks that
+// can't be delivered to the channel, because it is not ready to receive, are
+// discarded.
+func (t *mTicker) subscribe() *subscriber {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	sub := newSubscriber()
+	t.subscribers[sub] = nil
+	return sub
+}
+
+func (t *mTicker) unsubscribe(subscriber *subscriber) {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	close(subscriber.tick)
+	delete(t.subscribers, subscriber)
+}
+
+// Stop stops the ticker, and closes
+// all subscribed channels
+func (t *mTicker) stop() {
+	t.tickerMux.Lock()
+	defer t.tickerMux.Unlock()
+
+	if !t.stopped && t.stopCh != nil {
+		// close all subscribed time chans
+		for sub := range t.subscribers {
+			close(sub.tick)
+		}
+		t.ticker.Stop()
+		t.stopCh <- struct{}{}
+	}
+	t.stopped = true
+}
+
+func (t *mTicker) tick() {
+	for {
+		select {
+		case tick := <-t.ticker.C:
+			t.mux.Lock()
+			for sub := range t.subscribers {
+				select {
+				case sub.tick <- tick:
+				default:
+					t.dropped++
+				}
+			}
+			t.mux.Unlock()
+		case <-t.stopCh:
+			return
+		}
+	}
+}

--- a/mticker.go
+++ b/mticker.go
@@ -65,7 +65,7 @@ func (t *mTicker) stop() {
 		t.stopCh <- struct{}{}
 		// close all subscribed time chans
 		for sub := range t.subscribers {
-			close(sub.tick)
+			t.unsubscribe(sub)
 		}
 	}
 }

--- a/mticker.go
+++ b/mticker.go
@@ -43,6 +43,8 @@ func newSubscriber() *subscriber {
 // can't be delivered to the channel, because it is not ready to receive, are
 // discarded.
 func (t *mTicker) subscribe() *subscriber {
+	t.mux.Lock()
+	defer t.mux.Unlock()
 	sub := newSubscriber()
 	t.subscribers[sub] = nil
 	return sub

--- a/mticker_test.go
+++ b/mticker_test.go
@@ -23,7 +23,7 @@ func TestUnsubscribe(t *testing.T) {
 	ticker := newMTicker(2 * time.Second)
 	sub := ticker.subscribe()
 
-	// assert 2 subscribers
+	// assert 1 subscribers
 	if len(ticker.subscribers) != 1 {
 		t.Fatal("Expectation: 1, Received:", len(ticker.subscribers))
 	}

--- a/mticker_test.go
+++ b/mticker_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSubscribe(t *testing.T) {
+	ticker := newMTicker(2 * time.Second)
+
+	// assert no subscribers
+	if len(ticker.subscribers) != 0 {
+		t.Fatal("Expectation: 0, Received:", len(ticker.subscribers))
+	}
+
+	ticker.subscribe()
+	if len(ticker.subscribers) != 1 {
+		t.Fatal("Expectation: 1, Received:", len(ticker.subscribers))
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	ticker := newMTicker(2 * time.Second)
+	sub := ticker.subscribe()
+
+	// assert 2 subscribers
+	if len(ticker.subscribers) != 1 {
+		t.Fatal("Expectation: 1, Received:", len(ticker.subscribers))
+	}
+
+	// assert chan unsubscribed
+	ticker.unsubscribe(sub)
+	if len(ticker.subscribers) != 0 {
+		t.Fatal("Expectation: 0, Received:", len(ticker.subscribers))
+	}
+
+	// assert chan closed
+	_, ok := <-sub.tick
+	if ok {
+		t.Fatal("Expectation: tick channel should be closed, Received: open channel")
+	}
+}
+
+func TestTick(t *testing.T) {
+	ticker := newMTicker(2 * time.Second)
+	sub1 := ticker.subscribe()
+	sub2 := ticker.subscribe()
+	sub3 := ticker.subscribe()
+
+	// tick is already called indirectly
+	// through "newMTicker()"
+	time.Sleep(2)
+
+	// assert time stamps are passed
+	// to subscribing channels
+	t1, ok1 := <-sub1.tick
+	t2, ok2 := <-sub2.tick
+	t3, ok3 := <-sub3.tick
+
+	if !ok1 || !ok2 || !ok3 || !(t1 == t2 && t1 == t3) {
+		t.Fatal("Expecation: all subscribed channels receive identical time stamps, Received:", t1, t2, t3)
+	}
+}
+
+func TestStop(t *testing.T) {
+	ticker := newMTicker(2 * time.Second)
+	sub1 := ticker.subscribe()
+	sub2 := ticker.subscribe()
+
+	ticker.stop()
+
+	// assert all subscribing
+	// channels closed
+	// assert chan closed
+	_, ok1 := <-sub1.tick
+	_, ok2 := <-sub2.tick
+
+	if ok1 || ok2 {
+		t.Fatal("Expectation: all tick channels should be closed, Received: open channel")
+	}
+
+}

--- a/mticker_test.go
+++ b/mticker_test.go
@@ -71,12 +71,15 @@ func TestStop(t *testing.T) {
 
 	// assert all subscribing
 	// channels closed
-	// assert chan closed
 	_, ok1 := <-sub1.tick
 	_, ok2 := <-sub2.tick
 
 	if ok1 || ok2 {
 		t.Fatal("Expectation: all tick channels should be closed, Received: open channel")
+	}
+
+	if len(ticker.subscribers) != 0 {
+		t.Fatal("Expectation: 0 subscribers, Received:", len(ticker.subscribers))
 	}
 
 }


### PR DESCRIPTION
Change Summary:
1. Remove Ticker form conn.write()
2. Add test to assert connections aren't blocked/locked by inability to access ticker chan.
3. create ticker that disseminates ticks to multiple subscribed channels

Memory Savings: 
A local benchmark with 12 concurrent connections (9 unique paths–1 path had 3 connections) for 6 ping sessions. Benchmark yielded the below results:

Multiple tickers (avg):
Alloc : 631704
Total Alloc : 631704
Sys : 3542140
Lookups : 24

Single ticker (avg):
Alloc :  629472
Total Alloc :  629472
Sys :  3542140
Lookups :  24

Next Steps:
This is a change I would merge w/ caution and testing, I was only able to perform a simple benchmark locally but would recommend a more comprehensive load test done in a staging environment. It would be worthwhile to see what the memory savings actually is w/ more load.
