### PR TITLE
Increase message limit

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -16,7 +16,7 @@ const (
 	pingPeriod = (pongWait * 9) / 10
 
 	// Maximum message size allowed from peer.
-	maxMessageSize = 512
+	maxMessageSize = 64 * 1024 // 64KB (65536 bytes)
 )
 
 type websocketManager interface {


### PR DESCRIPTION
**Change Summary**:
- The WebSocket read limit is increased from 512 byte to 64 KB to support real-time collaborative editing (Yjs) in Gutenberg RTC. The 64 KB value was chosen because:

**Rationale**
- Typical Yjs usage – Incremental CRDT updates are usually small, but initial syncs and large edits can reach tens of KB. 64 KB accommodates these cases while avoiding the largest payloads.
- Industry practice – Other real-time systems (e.g. WebRTC datachannels) use 64 KB as a practical per-message cap, so 64 KB fits established patterns.
- Risk control – It is well above normal traffic but low enough to discourage abuse and avoid excessive memory use on high-traffic channels.